### PR TITLE
Feature/initialise admin route

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@
 API_KEY="1234"
 WORKSPACE_SLUG="your-orbit-workspace"
 ORBIT_TAG="any-tag" # The tag the members will need to be filtered with to be included in the directory
+ROOT_USER_EMAIL="delete44@example.com" # The email used to create the first admin user in /api/initialise-admin-member
 
 # -------------------------------------------------------------------------
 # To use a local mailer instead, ie node-http & mailhog, add the following:

--- a/pages/api/initialise-admin-member.js
+++ b/pages/api/initialise-admin-member.js
@@ -30,7 +30,8 @@ export default async function handle(req, res) {
 
     res.status(200).json(member);
   } catch (e) {
-    res.status(500).json({ error: e.message });
+    console.error(`Something went wrong. ${e.message}`);
+    res.status(500);
   } finally {
     await prisma.$disconnect();
   }

--- a/pages/api/initialise-admin-member.js
+++ b/pages/api/initialise-admin-member.js
@@ -31,7 +31,7 @@ export default async function handle(req, res) {
     res.status(200).json(member);
   } catch (e) {
     console.error(`Something went wrong. ${e.message}`);
-    res.status(500);
+    res.status(500).send();
   } finally {
     await prisma.$disconnect();
   }

--- a/pages/api/initialise-admin-member.js
+++ b/pages/api/initialise-admin-member.js
@@ -1,0 +1,37 @@
+import prisma from "../../lib/db";
+import { getAllMembers } from "../../helpers/prisma-helpers";
+
+export default async function handle(req, res) {
+  try {
+    if (req.method !== "POST") {
+      console.error("Only POST requests permitted");
+      res.status(405).send();
+      return;
+    }
+
+    const members = await getAllMembers();
+
+    if (members.length > 0) {
+      console.error(
+        "This request can only be used to instantiate the first member"
+      );
+      res.status(409).send();
+      return;
+    }
+
+    const member = await prisma.member.create({
+      data: {
+        email: process.env.ROOT_USER_EMAIL,
+        admin: true,
+        name: req.body.name,
+        avatar_url: req.body.avatar_url,
+      },
+    });
+
+    res.status(200).json(member);
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  } finally {
+    await prisma.$disconnect();
+  }
+}

--- a/pages/api/initialise-admin-member.test.js
+++ b/pages/api/initialise-admin-member.test.js
@@ -33,6 +33,7 @@ describe("/api/initialise-admin-member", () => {
     const req = { method: "GET" };
 
     await handle(req, res);
+
     expect(res.status).toHaveBeenCalledWith(405);
     expect(res.send).toHaveBeenCalled();
   });
@@ -41,10 +42,10 @@ describe("/api/initialise-admin-member", () => {
     getAllMembers.mockResolvedValueOnce([
       { id: 1, email: "existing@member.com" },
     ]);
-
     const req = { method: "POST" };
 
     await handle(req, res);
+
     expect(res.status).toHaveBeenCalledWith(409);
     expect(res.send).toHaveBeenCalled();
   });
@@ -61,7 +62,18 @@ describe("/api/initialise-admin-member", () => {
     };
 
     await handle(req, res);
+
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({ id: 1, email: "root@user.com" });
+  });
+
+  it("responds with 500 when prisma query fails", async () => {
+    getAllMembers.mockRejectedValueOnce(new Error("Prisma Error"));
+    const req = { method: "POST" };
+
+    await handle(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.send).toHaveBeenCalled();
   });
 });

--- a/pages/api/initialise-admin-member.test.js
+++ b/pages/api/initialise-admin-member.test.js
@@ -1,0 +1,67 @@
+import prisma from "../../lib/db";
+import handle from "./initialise-admin-member";
+import { getAllMembers } from "../../helpers/prisma-helpers";
+
+// mock the Prisma client
+jest.mock("../../lib/db", () => ({
+  member: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+  },
+  $disconnect: jest.fn(),
+}));
+
+jest.mock("../../helpers/prisma-helpers", () => ({
+  getAllMembers: jest.fn(),
+}));
+
+const res = {
+  // mockReturnThis() is used here to return the mock object itself as the
+  // result of `.status`. This is because we chain methods in the code itself,
+  // ie `res.status(409).send();`
+  status: jest.fn().mockReturnThis(),
+  send: jest.fn(),
+  json: jest.fn(),
+};
+
+describe("/api/initialise-admin-member", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("responds with 405 when request method is not POST", async () => {
+    const req = { method: "GET" };
+
+    await handle(req, res);
+    expect(res.status).toHaveBeenCalledWith(405);
+    expect(res.send).toHaveBeenCalled();
+  });
+
+  it("responds with 409 when there are already members", async () => {
+    getAllMembers.mockResolvedValueOnce([
+      { id: 1, email: "existing@member.com" },
+    ]);
+
+    const req = { method: "POST" };
+
+    await handle(req, res);
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.send).toHaveBeenCalled();
+  });
+
+  it("creates and responds with a member when request is valid", async () => {
+    getAllMembers.mockResolvedValueOnce([]);
+    prisma.member.create.mockResolvedValueOnce({
+      id: 1,
+      email: "root@user.com",
+    });
+    const req = {
+      method: "POST",
+      body: { name: "Root User", avatar_url: "avatar.com/root" },
+    };
+
+    await handle(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ id: 1, email: "root@user.com" });
+  });
+});


### PR DESCRIPTION
- [x] Adds POST /api/initialise-admin-member, that will pull an email from env vars and create a new admin member if no other member exists
- [x] Pulling email from env vars so this can't be abused if someone creates a new directory with an empty DB