### PR TITLE
Fix/tidy up api routes

### DIFF
--- a/helpers/api-helpers.js
+++ b/helpers/api-helpers.js
@@ -1,0 +1,60 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "../pages/api/auth/[...nextauth]";
+
+/**
+ * helper methods for common HTTP request checks.
+ *
+ * example usage:
+ *
+ * import { withAuthCheck, withMethodCheck } from './helper';
+ *
+ * async function handle(req, res) {
+ *   // Do something
+ * }
+ *
+ * export default withAuthCheck(withMethodCheck(handle));
+ */
+
+/**
+ * higher-order function to check if a user is authenticated before
+ * handling an HTTP request.
+ *
+ * @param {Function} handler - the function to handle the HTTP request
+ * @returns {Function} the new handler function with the added authentication check
+ */
+export const withAuthCheck = (handler) => {
+  return async (req, res) => {
+    const session = await getServerSession(req, res, authOptions);
+
+    if (!session) {
+      res.status(401).json({
+        message: "Unauthorized. Please sign in before accessing this resource.",
+      });
+      return;
+    }
+
+    // If the check passed, call the actual handler
+    return handler(req, res);
+  };
+};
+
+/**
+ * higher-order function to check the method of an HTTP request before
+ * handling it.
+ *
+ * @param {Function} handler - the function to handle the HTTP request
+ * @param {string} method - the HTTP method that the request should be
+ * @returns {Function} the new handler function with the added method check
+ */
+export const withMethodCheck = (handler, method = "POST") => {
+  return (req, res) => {
+    if (req.method !== method) {
+      console.error(`Only ${method} requests permitted`);
+      res.status(405).send();
+      return;
+    }
+
+    // If the check passed, call the actual handler
+    return handler(req, res);
+  };
+};

--- a/helpers/api-helpers.js
+++ b/helpers/api-helpers.js
@@ -39,6 +39,30 @@ export const withAuthCheck = (handler) => {
 };
 
 /**
+ * higher-order function to check if a user is an admin before
+ * handling an HTTP request.
+ *
+ * @param {Function} handler - the function to handle the HTTP request
+ * @returns {Function} the new handler function with the added authentication check
+ */
+export const withAdminCheck = (handler) => {
+  return async (req, res) => {
+    const session = await getServerSession(req, res, authOptions);
+
+    if (!session?.user.admin) {
+      res.status(401).json({
+        message:
+          "Unauthorized. Please contact an admin to complete this action.",
+      });
+      return;
+    }
+
+    // If the check passed, call the actual handler
+    return handler(req, res);
+  };
+};
+
+/**
  * higher-order function to check the method of an HTTP request before
  * handling it.
  *

--- a/helpers/api-helpers.test.js
+++ b/helpers/api-helpers.test.js
@@ -1,0 +1,80 @@
+import { withAuthCheck, withMethodCheck } from "./api-helpers";
+
+// ------------------------------------------------------
+// Required when testing a route with withAuthCheck
+jest.mock("../pages/api/auth/[...nextauth]", () => ({
+  authOptions: {},
+}));
+
+// We'll overwrite this mock in the individual test cases
+jest.mock("next-auth/next", () => ({
+  getServerSession: jest.fn(),
+}));
+// ------------------------------------------------------
+
+let req, res, handler, getServerSessionMock;
+
+beforeEach(() => {
+  // Set up some mock middleware
+  req = { method: "POST" };
+  res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+    send: jest.fn(),
+  };
+  handler = jest.fn();
+
+  // Reset the mock for getServerSession
+  getServerSessionMock = require("next-auth/next").getServerSession;
+  getServerSessionMock.mockClear();
+});
+
+describe("withAuthCheck", () => {
+  it("calls the handler if the user is authenticated", async () => {
+    // Mock a valid session
+    getServerSessionMock.mockResolvedValue({
+      user: { email: "test@test.com" },
+    });
+
+    const handlerWithAuthCheck = withAuthCheck(handler);
+    await handlerWithAuthCheck(req, res);
+
+    expect(handler).toBeCalledWith(req, res);
+    expect(res.status).not.toBeCalled();
+  });
+
+  it("returns 401 if the user is not authenticated", async () => {
+    // Mock no session
+    getServerSessionMock.mockResolvedValue(null);
+
+    const handlerWithAuthCheck = withAuthCheck(handler);
+    await handlerWithAuthCheck(req, res);
+
+    expect(handler).not.toBeCalled();
+    expect(res.status).toBeCalledWith(401);
+    expect(res.json).toBeCalledWith({
+      message: "Unauthorized. Please sign in before accessing this resource.",
+    });
+  });
+});
+
+describe("withMethodCheck", () => {
+  it("calls the handler if the request method matches", () => {
+    const handlerWithMethodCheck = withMethodCheck(handler);
+    handlerWithMethodCheck(req, res);
+
+    expect(handler).toBeCalledWith(req, res);
+    expect(res.status).not.toBeCalled();
+  });
+
+  it("returns 405 if the request method does not match", () => {
+    req.method = "GET";
+
+    const handlerWithMethodCheck = withMethodCheck(handler);
+    handlerWithMethodCheck(req, res);
+
+    expect(handler).not.toBeCalled();
+    expect(res.status).toBeCalledWith(405);
+    expect(res.send).toBeCalledTimes(1);
+  });
+});

--- a/helpers/api-helpers.test.js
+++ b/helpers/api-helpers.test.js
@@ -1,4 +1,4 @@
-import { withAuthCheck, withMethodCheck } from "./api-helpers";
+import { withAuthCheck, withAdminCheck, withMethodCheck } from "./api-helpers";
 
 // ------------------------------------------------------
 // Required when testing a route with withAuthCheck
@@ -54,6 +54,51 @@ describe("withAuthCheck", () => {
     expect(res.status).toBeCalledWith(401);
     expect(res.json).toBeCalledWith({
       message: "Unauthorized. Please sign in before accessing this resource.",
+    });
+  });
+});
+
+describe("withAdminCheck", () => {
+  it("calls the handler if the user is an admin", async () => {
+    // Mock a session for an admin user for this test case
+    getServerSessionMock.mockResolvedValue({
+      user: { email: "admin@test.com", admin: true },
+    });
+
+    const handlerWithAdminCheck = withAdminCheck(handler);
+    await handlerWithAdminCheck(req, res);
+
+    expect(handler).toBeCalledWith(req, res);
+    expect(res.status).not.toBeCalled();
+  });
+
+  it("returns 401 if the user is not an admin", async () => {
+    // Mock a session for a non-admin user for this test case
+    getServerSessionMock.mockResolvedValue({
+      user: { email: "user@test.com", admin: false },
+    });
+
+    const handlerWithAdminCheck = withAdminCheck(handler);
+    await handlerWithAdminCheck(req, res);
+
+    expect(handler).not.toBeCalled();
+    expect(res.status).toBeCalledWith(401);
+    expect(res.json).toBeCalledWith({
+      message: "Unauthorized. Please contact an admin to complete this action.",
+    });
+  });
+
+  it("returns 401 if the user is not authenticated", async () => {
+    // Mock no session for this test case
+    getServerSessionMock.mockResolvedValue(null);
+
+    const handlerWithAdminCheck = withAdminCheck(handler);
+    await handlerWithAdminCheck(req, res);
+
+    expect(handler).not.toBeCalled();
+    expect(res.status).toBeCalledWith(401);
+    expect(res.json).toBeCalledWith({
+      message: "Unauthorized. Please contact an admin to complete this action.",
     });
   });
 });

--- a/pages/api/members.js
+++ b/pages/api/members.js
@@ -1,7 +1,8 @@
 import prisma from "../../lib/db";
 import { getAllMembers } from "../../helpers/prisma-helpers";
+import { withAuthCheck, withMethodCheck } from "../../helpers/api-helpers";
 
-export default async function handle(req, res) {
+export async function handle(req, res) {
   try {
     const members = await getAllMembers();
 
@@ -13,3 +14,5 @@ export default async function handle(req, res) {
     await prisma.$disconnect();
   }
 }
+
+export default withAuthCheck(withMethodCheck(handle, "GET"));

--- a/pages/api/members.js
+++ b/pages/api/members.js
@@ -2,7 +2,7 @@ import prisma from "../../lib/db";
 import { getAllMembers } from "../../helpers/prisma-helpers";
 import { withAuthCheck, withMethodCheck } from "../../helpers/api-helpers";
 
-export async function handle(req, res) {
+async function handle(req, res) {
   try {
     const members = await getAllMembers();
 

--- a/pages/api/members.test.js
+++ b/pages/api/members.test.js
@@ -1,5 +1,14 @@
-import handle from "./members";
+import { handle } from "./members";
 import { getAllMembers } from "../../helpers/prisma-helpers";
+
+// Required when testing a route with withAuthCheck
+jest.mock("./auth/[...nextauth]", () => ({
+  authOptions: {},
+}));
+
+jest.mock("next-auth/next", () => ({
+  getServerSession: jest.fn().mockReturnValue(),
+}));
 
 jest.mock("../../helpers/prisma-helpers", () => ({
   getAllMembers: jest.fn(),

--- a/pages/api/members.test.js
+++ b/pages/api/members.test.js
@@ -1,14 +1,16 @@
 import { handle } from "./members";
 import { getAllMembers } from "../../helpers/prisma-helpers";
 
+// ------------------------------------------------------
 // Required when testing a route with withAuthCheck
 jest.mock("./auth/[...nextauth]", () => ({
   authOptions: {},
 }));
 
 jest.mock("next-auth/next", () => ({
-  getServerSession: jest.fn().mockReturnValue(),
+  getServerSession: jest.fn(),
 }));
+// ------------------------------------------------------
 
 jest.mock("../../helpers/prisma-helpers", () => ({
   getAllMembers: jest.fn(),

--- a/pages/api/members.test.js
+++ b/pages/api/members.test.js
@@ -1,4 +1,4 @@
-import { handle } from "./members";
+import handle from "./members";
 import { getAllMembers } from "../../helpers/prisma-helpers";
 
 // ------------------------------------------------------
@@ -7,8 +7,11 @@ jest.mock("./auth/[...nextauth]", () => ({
   authOptions: {},
 }));
 
+// Mock a valid session
 jest.mock("next-auth/next", () => ({
-  getServerSession: jest.fn(),
+  getServerSession: jest.fn().mockResolvedValue({
+    user: { email: "test@test.com" },
+  }),
 }));
 // ------------------------------------------------------
 

--- a/pages/api/populate-members-table.js
+++ b/pages/api/populate-members-table.js
@@ -4,14 +4,13 @@ import {
   getAllMembers,
   getAllMemberEmails,
 } from "../../helpers/prisma-helpers";
+import {
+  withAuthCheck,
+  withAdminCheck,
+  withMethodCheck,
+} from "../../helpers/api-helpers";
 
-export default async function handle(req, res) {
-  if (req.method !== "POST") {
-    console.error("Only POST requests permitted");
-    res.status(405).send();
-    return;
-  }
-
+async function handle(req, res) {
   const { members, included } = await fetchOrbitData();
 
   // Delete all existing identities
@@ -90,3 +89,5 @@ export async function fetchOrbitData(
 
   return { members, included };
 }
+
+export default withAuthCheck(withMethodCheck(withAdminCheck(handle)));

--- a/pages/api/populate-members-table.test.js
+++ b/pages/api/populate-members-table.test.js
@@ -1,6 +1,20 @@
 import { membersToRemove } from "./populate-members-table";
 import { getAllMemberEmails } from "../../helpers/prisma-helpers";
 
+// ------------------------------------------------------
+// Required when testing a route with withAuthCheck
+jest.mock("./auth/[...nextauth]", () => ({
+  authOptions: {},
+}));
+
+// Mock a valid session
+jest.mock("next-auth/next", () => ({
+  getServerSession: jest.fn().mockResolvedValue({
+    user: { email: "test@test.com" },
+  }),
+}));
+// ------------------------------------------------------
+
 jest.mock("../../helpers/prisma-helpers", () => ({
   getAllMemberEmails: jest.fn(),
 }));

--- a/pages/api/update-member.js
+++ b/pages/api/update-member.js
@@ -1,6 +1,7 @@
 import { updateMember } from "../../helpers/prisma-helpers";
+import { withAuthCheck, withMethodCheck } from "../../helpers/api-helpers";
 
-export default async function handle(req, res) {
+async function handle(req, res) {
   if (req.method !== "POST") {
     console.error("Only POST requests permitted");
     res.status(405).send();
@@ -19,3 +20,5 @@ export default async function handle(req, res) {
     res.status(400).send();
   }
 }
+
+export default withAuthCheck(withMethodCheck(handle));

--- a/pages/api/update-member.js
+++ b/pages/api/update-member.js
@@ -2,12 +2,6 @@ import { updateMember } from "../../helpers/prisma-helpers";
 import { withAuthCheck, withMethodCheck } from "../../helpers/api-helpers";
 
 async function handle(req, res) {
-  if (req.method !== "POST") {
-    console.error("Only POST requests permitted");
-    res.status(405).send();
-    return;
-  }
-
   try {
     // Attempt to update the user
     await updateMember(req.body);

--- a/pages/api/update-member.test.js
+++ b/pages/api/update-member.test.js
@@ -1,6 +1,20 @@
 import { updateMember } from "../../helpers/prisma-helpers";
 import handle from "./update-member";
 
+// ------------------------------------------------------
+// Required when testing a route with withAuthCheck
+jest.mock("./auth/[...nextauth]", () => ({
+  authOptions: {},
+}));
+
+// Mock a valid session
+jest.mock("next-auth/next", () => ({
+  getServerSession: jest.fn().mockResolvedValue({
+    user: { email: "test@test.com" },
+  }),
+}));
+// ------------------------------------------------------
+
 // Mock the updateMember helper function
 jest.mock("../../helpers/prisma-helpers", () => ({
   updateMember: jest.fn(),
@@ -14,15 +28,6 @@ const res = {
 describe("/api/update-member", () => {
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  it("responds with 405 when request method is not POST", async () => {
-    const req = { method: "GET" };
-
-    await handle(req, res);
-
-    expect(res.status).toHaveBeenCalledWith(405);
-    expect(res.send).toHaveBeenCalled();
   });
 
   it("responds with 200 when request is valid", async () => {

--- a/pages/index.js
+++ b/pages/index.js
@@ -56,7 +56,11 @@ export default function Home({ initialMembers }) {
 // Fetch members from /api/members route on component load (ie, initialise the data)
 // This is set as default value for the useState for members
 export async function getServerSideProps(context) {
-  const res = await fetch(`http://${context.req.headers.host}/api/members`);
+  const res = await fetch(`http://${context.req.headers.host}/api/members`, {
+    headers: {
+      cookie: context.req.headers.cookie,
+    },
+  });
   const data = await res.json();
 
   if (!data) {


### PR DESCRIPTION
- [x] Adds admin-only and signedin-only checks to API routes
- [x] Migrates these to a common helper because they get repeated a whole bunch
- [x] I bloody hate dealing with javascript config errors